### PR TITLE
Fix visible supporter count

### DIFF
--- a/recent_supporters.module
+++ b/recent_supporters.module
@@ -753,7 +753,7 @@ function recent_supporters_field_formatter_view($entity_type, $entity, $field, $
               'cycleSupporters' => $options['cycle_toggle'],
               'showCountry' => $options['country_toggle'],
               'showComment' => $options['comment_toggle'],
-              'visibleCount' => $options['visible_count'],
+              'maxSupportersVisible' => $options['visible_count'],
               'field_name' => $field_name,
               'delta' => $delta,
               'allActions' => FALSE,


### PR DESCRIPTION
Using js, there are always 6 supporters displayed, ignoring all custom settings. It seems the variable was renamed at some point → using the correct variable name fixes the issue.