### PR TITLE
Comment handling fixes

### DIFF
--- a/recent_supporters_webform/recent_supporters_webform.admin.inc
+++ b/recent_supporters_webform/recent_supporters_webform.admin.inc
@@ -54,6 +54,10 @@ function recent_supporters_webform_settings_form($form, &$form_state) {
     '#type' => 'textfield',
     '#title' => t('Country'),
   );
+  $element['comment'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Comment'),
+  );
   foreach ($mapping as $field => $form_keys) {
     $element[$field]['#default_value'] = implode(', ', $form_keys);
   }

--- a/recent_supporters_webform/recent_supporters_webform.module
+++ b/recent_supporters_webform/recent_supporters_webform.module
@@ -26,7 +26,7 @@ function recent_supporters_webform_mapping() {
     'first_name' => array('first_name', 'firstname'),
     'last_name' => array('last_name', 'lastname'),
     'country' => array('country'),
-    'comment' => array('comment', 'email_body'),
+    'comment' => array('comment'),
   );
   return $settings;
 }

--- a/recent_supporters_webform/src/WebformBackend.php
+++ b/recent_supporters_webform/src/WebformBackend.php
@@ -2,21 +2,36 @@
 
 namespace Drupal\recent_supporters_webform;
 
-use \Drupal\recent_supporters\BackendBase;
-use \Drupal\recent_supporters\RequestParams;
+use Drupal\recent_supporters\BackendBase;
+use Drupal\recent_supporters\RequestParams;
 
 /**
- * Loader for recent supporters.
+ * Backend plugin that loads data from the {recent_supporters_webform} table.
  */
 class WebformBackend extends BackendBase {
+
+  /**
+   * Get label of this plugin for the admin interface.
+   */
   public static function label() {
     return t('Webform submissions');
   }
 
+  /**
+   * Get recent supporters for one action and its translations.
+   *
+   * @param \Drupal\recent_supporters\RequestParams $params
+   *   Parameters for the query.
+   *
+   * @return string[][]
+   *   Array of data about recent supporters. Each entry is an associative array
+   *   containing the data of one supporter.
+   */
   public function recentOnOneAction(RequestParams $params) {
-      $config = $params->getParams();
+    $config = $params->getParams();
+    $comment_field = $config['comment_toggle'] ? ', w.comment' : '';
     $sql = <<<SQL
-SELECT n.nid, n.tnid, w.first_name, w.last_name, w.timestamp, w.country, w.comment
+SELECT n.nid, n.tnid, w.first_name, w.last_name, w.timestamp, w.country$comment_field
 FROM {recent_supporters_webform} w
   INNER JOIN {node} n USING(nid)
 WHERE n.status = 1
@@ -24,18 +39,32 @@ WHERE n.status = 1
 ORDER BY w.timestamp DESC
 SQL;
     $result = db_query_range($sql, 0, $config['limit'], array(':nid' => $config['nid']));
-
     return $this->buildSupporterList($result, $config['name_display']);
   }
 
+  /**
+   * Get recent supporters for all live actions in this installation.
+   *
+   * @param \Drupal\recent_supporters\RequestParams $params
+   *   Parameters for the query.
+   *
+   * @return string[][]
+   *   Array of data about recent supporters. Each entry is an associative array
+   *   containing the data of one supporter.
+   */
   public function recentOnAllActions(RequestParams $params) {
     $config = $params->getParams();
     if (!$config['types']) {
       return [];
     }
-    // get translations: na - activity node, nt - any available node translated into $lang, no - the "original" node (ie. the translation source)
+    $comment_field = $config['comment_toggle'] ? ', w.comment' : '';
+    // Get translated node data in the following order of precendence:
+    // 1. nt - A translation of the webform submission node to the current
+    //         user’s language.
+    // 2. no - The translation source of the submission node.
+    // 3. na - The node of the webform submission.
     $sql = <<<SQL
-SELECT w.first_name, w.last_name, w.timestamp, w.country, w.comment,
+SELECT w.first_name, w.last_name, w.timestamp, w.country$comment_field,
   na.nid, na.tnid, na.type AS action_type, na.status,
   COALESCE(nt.title, no.title, na.title) AS action_title,
   COALESCE(nt.tnid, no.tnid, na.nid) AS action_nid,
@@ -48,7 +77,7 @@ WHERE na.status = 1 AND na.type IN (:types)
   ORDER BY w.timestamp DESC
 SQL;
     $result = db_query_range($sql, 0, $config['limit'], array(':types' => $config['types'], ':lang' => $config['lang']));
-    $rows = array();
     return $this->buildSupporterList($result, $config['name_display']);
   }
+
 }

--- a/src/BackendBase.php
+++ b/src/BackendBase.php
@@ -18,6 +18,7 @@ abstract class BackendBase {
       'backend' => get_called_class(),
       'limit' => $options['query_limit'],
       'name_display' => $options['name_display'],
+      'comment_toggle' => $options['comment_toggle'],
     );
     if ($node) {
       return new RequestParams($config + array('nid' => $node->nid));

--- a/src/RequestParams.php
+++ b/src/RequestParams.php
@@ -9,6 +9,7 @@ class RequestParams {
     $this->params = $params + array(
       'limit' => 10,
       'name_display' => RECENT_SUPPORTERS_NAME_DISPLAY_DEFAULT,
+      'comment_toggle' => FALSE,
       'hash' => '',
     );
   }


### PR DESCRIPTION
* Add missing field to the admin configuration form.
* Remove `email_body` from the default mapping as this is unexpected for users.
* Don’t show comments in the polling results if showing comments is disabled.