### PR TITLE
Don’t rely on (possibly anonymized) $submission->remote_addr.

### DIFF
--- a/recent_supporters_webform/recent_supporters_webform.module
+++ b/recent_supporters_webform/recent_supporters_webform.module
@@ -84,7 +84,7 @@ function recent_supporters_webform_webform_submission_insert($node, $submission)
   // Optionally get the country from geoip.
   if (!$fields['country'] && function_exists('geoip_country_code_by_name')) {
     // Use @, see: https://bugs.php.net/bug.php?id=59753
-    $fields['country'] = @geoip_country_code_by_name($submission->remote_addr);
+    $fields['country'] = @geoip_country_code_by_name(ip_address());
   }
 
   db_merge('recent_supporters_webform')


### PR DESCRIPTION
Webform might anonymize the submission IP-address. This means strings other than ip addresses might be stored in $submission->remote_addr. It seems that geoip_country_code_by_name() has serious performance issues when it’s confronted with arbitrary strings.