### PR TITLE
Prevent “jumping” when cycling

### DIFF
--- a/jquery.recent-supporters.js
+++ b/jquery.recent-supporters.js
@@ -265,10 +265,24 @@
       // move last element to top in list and show hide
       // if there is at least one supporter more loaded then shown
       if (supporterElements.length > settings.maxSupportersVisible) {
-        var minHeight = $container.height();
-        $container.css({minHeight: minHeight + 'px'});
-        $('li:visible', $ul).last().slideUp({duration: 200, easing: settings.cycleEasing});
-        supporterElements.last().hide().detach().prependTo($ul).slideDown({duration: 200, easing: settings.cycleEasing});
+        var currentHeight = $container.height();
+        $container.css({
+          // Prevent the container from shrinking while a large supporter cycles out of view.
+          minHeight: currentHeight + 'px',
+          // Set a max-height during the slide up animation to prevent “jumping”.
+          maxHeight: currentHeight + 'px'
+        });
+        $('li:visible', $ul).last().slideUp({
+          duration: 200,
+          easing: settings.cycleEasing,
+          complete: function() {
+            $container.css({maxHeight: ''});
+          }
+        });
+        supporterElements.last().hide().detach().prependTo($ul).slideDown({
+          duration: 200,
+          easing: settings.cycleEasing
+        });
       }
     }
 


### PR DESCRIPTION
This makes the transition a little less smooth when a higher item appears for the first time but prevents a height change occurring on each cycle for a few milliseconds while both the old and the new item are (partly) visible.